### PR TITLE
Use the correct attempt number

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ Recovery.prototype.backoff = function backoff(fn, opts) {
   //
   opts.scheduled = opts.attempt !== 1
     ? Math.min(Math.round(
-        (Math.random() + 1) * opts.min * Math.pow(opts.factor, opts.attempt)
+        (Math.random() + 1) * opts.min * Math.pow(opts.factor, opts.attempt - 1)
       ), opts.max)
     : opts.min;
 


### PR DESCRIPTION
Assume that the minimum delay is set to 100.
The expected timeouts are `100 -> 200 -> 400 -> 800 ...` but right now we start with attempt number `2` so we have something like this `100 -> 400 -> 800 ...`.
This patch fixes the issue.

Question: Why the first attempt is not randomized? If the server restarts immediately isn't it DDoSed?